### PR TITLE
43 permission manager class

### DIFF
--- a/app/app/build.gradle
+++ b/app/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "cmput.app.catch_me_if_you_scan"
-        minSdk 22
+        minSdk 23
         targetSdk 33
         versionCode 1
         versionName "1.0"

--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/app/src/main/java/cmput/app/catch_me_if_you_scan/LoginActivity.java
+++ b/app/app/src/main/java/cmput/app/catch_me_if_you_scan/LoginActivity.java
@@ -1,5 +1,6 @@
 package cmput.app.catch_me_if_you_scan;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.app.Activity;
@@ -10,6 +11,8 @@ import android.view.View;
 import android.widget.Button;
 
 public class LoginActivity extends AppCompatActivity {
+
+    PermissionManager permissionManager;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -17,13 +20,29 @@ public class LoginActivity extends AppCompatActivity {
 
         Button signUp = findViewById(R.id.sign_up_button);
 
+        permissionManager = new PermissionManager(LoginActivity.this);
+        permissionManager.requestAllPermissions();
+
         signUp.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent i = new Intent(LoginActivity.this, MainActivity.class);
-                startActivity(i);
+                if (permissionManager.hasAllPermissions()) {
+                    Intent i = new Intent(LoginActivity.this, MainActivity.class);
+                    startActivity(i);
+                } else {
+                    permissionManager.requestAllPermissions();
+                }
+
             }
         });
 
     }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        permissionManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
 }
+
+

--- a/app/app/src/main/java/cmput/app/catch_me_if_you_scan/PermissionDialog.java
+++ b/app/app/src/main/java/cmput/app/catch_me_if_you_scan/PermissionDialog.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.widget.Button;
 
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 
 public class PermissionDialog extends DialogFragment {
@@ -33,11 +34,15 @@ public class PermissionDialog extends DialogFragment {
                     dialog.cancel();
                 });
         AlertDialog dialog = builder.create();
+
+        System.out.println("HELOOooOOO");
         dialog.setOnShowListener(new DialogInterface.OnShowListener() {
             @Override
             public void onShow(DialogInterface dialog) {
                 Button negativeButton = ((AlertDialog) dialog).getButton(DialogInterface.BUTTON_NEGATIVE);
-                negativeButton.setTextColor(getResources().getColor(android.R.color.holo_red_light));
+
+                negativeButton.setTextColor(ContextCompat.getColor(((AlertDialog) dialog).getContext(), android.R.color.holo_red_light));
+
             }
         });
         return dialog;

--- a/app/app/src/main/java/cmput/app/catch_me_if_you_scan/PermissionDialog.java
+++ b/app/app/src/main/java/cmput/app/catch_me_if_you_scan/PermissionDialog.java
@@ -1,0 +1,46 @@
+package cmput.app.catch_me_if_you_scan;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.widget.Button;
+
+import androidx.fragment.app.DialogFragment;
+
+public class PermissionDialog extends DialogFragment {
+
+
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setMessage("This app requires the camera and location permission.\n\nPlease manually grant the permission in the app settings.")
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        // Open app settings
+                        Intent intent = new Intent();
+                        intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                        Uri uri = Uri.fromParts("package", getActivity().getPackageName(), null);
+                        intent.setData(uri);
+                        startActivity(intent);
+                    }
+                }).setNegativeButton("CANCEL", (dialog, id) -> {
+                    // Dismiss the dialog
+                    dialog.cancel();
+                });
+        AlertDialog dialog = builder.create();
+        dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface dialog) {
+                Button negativeButton = ((AlertDialog) dialog).getButton(DialogInterface.BUTTON_NEGATIVE);
+                negativeButton.setTextColor(getResources().getColor(android.R.color.holo_red_light));
+            }
+        });
+        return dialog;
+    }
+}
+

--- a/app/app/src/main/java/cmput/app/catch_me_if_you_scan/PermissionManager.java
+++ b/app/app/src/main/java/cmput/app/catch_me_if_you_scan/PermissionManager.java
@@ -1,0 +1,2 @@
+package cmput.app.catch_me_if_you_scan;public class PermissionManager {
+}

--- a/app/app/src/main/java/cmput/app/catch_me_if_you_scan/PermissionManager.java
+++ b/app/app/src/main/java/cmput/app/catch_me_if_you_scan/PermissionManager.java
@@ -1,2 +1,94 @@
-package cmput.app.catch_me_if_you_scan;public class PermissionManager {
+package cmput.app.catch_me_if_you_scan;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.ActivityCompat;
+import androidx.fragment.app.FragmentActivity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PermissionManager {
+
+    private static final int PERMISSION_REQUEST_CODE = 101;
+    Context context;
+
+    public PermissionManager(Context context) {
+        this.context = context;
+    }
+
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    public void requestAllPermissions() {
+        List<String> permissionsNeeded = new ArrayList<>();
+
+        if (context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            permissionsNeeded.add(Manifest.permission.ACCESS_FINE_LOCATION);
+        }
+
+        if (context.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            permissionsNeeded.add(Manifest.permission.ACCESS_COARSE_LOCATION);
+        }
+
+        if (context.checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            permissionsNeeded.add(Manifest.permission.CAMERA);
+        }
+
+        if (!permissionsNeeded.isEmpty()) {
+            ActivityCompat.requestPermissions((Activity) context, permissionsNeeded.toArray(new String[permissionsNeeded.size()]), PERMISSION_REQUEST_CODE);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    public boolean hasAllPermissions() {
+        return context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+                && context.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+                && context.checkSelfPermission(Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode == PERMISSION_REQUEST_CODE) {
+            boolean allPermissionsGranted = true;
+            boolean showRationale = false;
+
+            for (int i = 0; i < permissions.length; i++) {
+                if (grantResults[i] != PackageManager.PERMISSION_GRANTED) {
+                    allPermissionsGranted = false;
+
+                    if (ActivityCompat.shouldShowRequestPermissionRationale((Activity) context, permissions[i])) {
+                        showRationale = true;
+                    } else {
+                        showRationale = false;
+                    }
+                }
+            }
+
+            if (allPermissionsGranted) {
+                // Do something when all permissions are granted
+                // None for the app's case.
+
+                // else is used to catch EVERY case that is not allPermissionsGranted. Including unforeseen cases.
+            } else {
+                if (showRationale) {
+                    // The user denied some permissions but did not check "Don't ask again"
+                    // Show an explanation to the user and request the permissions again
+                    Toast.makeText(context, "Please grant all the permissions to use the app", Toast.LENGTH_SHORT).show();
+
+                } else {
+                    // The user denied some permissions and checked "Don't ask again"
+                    // We can either disable some functionality of the app or redirect the user to app settings
+                    PermissionDialog dialogFragment = new PermissionDialog();
+                    dialogFragment.show(((FragmentActivity) context).getSupportFragmentManager(), "permission_denied_dialog");
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Device Permission handling is finalized. The current implementation uses a PermissionManager to simplify the calls in an activity.

The permission handling is currently intended to be used only during login and prevents the user from using the app if any permissions are rejected. If the user chooses "don't ask again" for the permission requests, a dialog fragment is shown for the rationale why the permissions are necessary. If the user confirms, the app opens the android settings for manual permission changes.

The changes include the addition of 2 classes, PermissionDialog and PermissionManager.

The LoginActivity has been altered to have the implementation of the PermissionManager.

Minimum SDK version is increased to 23+. Current implementation does not work for lower versions.