### PR TITLE
fixed issue with illegal hex value

### DIFF
--- a/app/app/src/main/java/cmput/app/catch_me_if_you_scan/MonsterController.java
+++ b/app/app/src/main/java/cmput/app/catch_me_if_you_scan/MonsterController.java
@@ -111,7 +111,7 @@ public class MonsterController {
             GeoPoint location = (GeoPoint) data.get("location");
             Blob envPhotoBlob = (Blob) data.get("envPhoto");
             byte[] envPhoto = envPhotoBlob.toBytes();
-            return (new Monster(name, score, document.getId(), location.getLongitude(), location.getLatitude(), envPhoto));
+            return (new Monster(name, score, document.getId().toString(), location.getLongitude(), location.getLatitude(), envPhoto));
         }
         return null;
     }
@@ -134,7 +134,7 @@ public class MonsterController {
                 GeoPoint location = (GeoPoint) data.get("location");
                 Blob envPhotoBlob = (Blob) data.get("envPhoto");
                 byte[] envPhoto = envPhotoBlob.toBytes();
-                Monster newMonster = new Monster(name, score, document.getId(), location.getLongitude(), location.getLatitude(), envPhoto);
+                Monster newMonster = new Monster(name, score, document.getId().toString(), location.getLongitude(), location.getLatitude(), envPhoto);
                 allMonsters.add(newMonster);
             }
         }
@@ -160,7 +160,7 @@ public class MonsterController {
                 GeoPoint location = (GeoPoint) data.get("location");
                 Blob envPhotoBlob = (Blob) data.get("envPhoto");
                 byte[] envPhoto = envPhotoBlob.toBytes();
-                newMonster = new Monster(monsterName, score, document.getId(), location.getLongitude(), location.getLatitude(), envPhoto);
+                newMonster = new Monster(monsterName, score, document.getId().toString(), location.getLongitude(), location.getLatitude(), envPhoto);
                 return newMonster;
             }
         }

--- a/app/app/src/main/java/cmput/app/catch_me_if_you_scan/UserController.java
+++ b/app/app/src/main/java/cmput/app/catch_me_if_you_scan/UserController.java
@@ -81,7 +81,7 @@ public class UserController {
             String deviceId = (String) data.get("deviceID");
             int score = ((Long) data.get("score")).intValue();
             String description = (String) data.get("description");
-            User fetchedUser = new User(deviceId, document.getId(), email, description);
+            User fetchedUser = new User(deviceId, document.getId().toString(), email, description);
             List<DocumentReference> monsters = (List<DocumentReference>) data.get("monstersScanned");
 
         /*
@@ -99,7 +99,7 @@ public class UserController {
                     int monsterScore = ((Long) monsterData.get("score")).intValue();
                     GeoPoint location = (GeoPoint) monsterData.get("location");
                     byte[] envPhoto = (byte[]) monsterData.get("envPhoto");
-                    fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId(), location.getLongitude(), location.getLatitude(), envPhoto));
+                    fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId().toString(), location.getLongitude(), location.getLatitude(), envPhoto));
                 }
             }
             return fetchedUser;
@@ -125,7 +125,7 @@ public class UserController {
                 String deviceId = (String) data.get("deviceID");
                 int score = ((Long) data.get("score")).intValue();
                 String description = (String) data.get("description");
-                fetchedUser = new User(deviceId, document.getId(), email, description);
+                fetchedUser = new User(deviceId, document.getId().toString(), email, description);
                 List<DocumentReference> monsters = (List<DocumentReference>) data.get("monstersScanned");
 
             /*
@@ -143,7 +143,7 @@ public class UserController {
                         int monsterScore = ((Long) monsterData.get("score")).intValue();
                         GeoPoint location = (GeoPoint) monsterData.get("location");
                         byte[] envPhoto = (byte[]) monsterData.get("envPhoto");
-                        fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId(), location.getLongitude(), location.getLatitude(), envPhoto));
+                        fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId().toString(), location.getLongitude(), location.getLatitude(), envPhoto));
                     }
                 }
                 return fetchedUser;
@@ -171,7 +171,7 @@ public class UserController {
                 String deviceId = (String) data.get("deviceID");
                 int score = ((Long) data.get("score")).intValue();
                 String description = (String) data.get("description");
-                fetchedUser = new User(deviceId, document.getId(), email, description);
+                fetchedUser = new User(deviceId, document.getId().toString(), email, description);
                 List<DocumentReference> monsters = (List<DocumentReference>) data.get("monstersScanned");
 
             /*
@@ -189,7 +189,7 @@ public class UserController {
                         int monsterScore = ((Long) monsterData.get("score")).intValue();
                         GeoPoint location = (GeoPoint) monsterData.get("location");
                         byte[] envPhoto = (byte[]) monsterData.get("envPhoto");
-                        fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId(), location.getLongitude(), location.getLatitude(), envPhoto));
+                        fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId().toString(), location.getLongitude(), location.getLatitude(), envPhoto));
                     }
                 }
                 return fetchedUser;
@@ -215,7 +215,7 @@ public class UserController {
                 String deviceId = (String) data.get("deviceID");
                 int score = ((Long) data.get("score")).intValue();
                 String description = (String) data.get("description");
-                User fetchedUser = new User(deviceId, document.getId(), email, description);
+                User fetchedUser = new User(deviceId, document.getId().toString(), email, description);
                 List<DocumentReference> monsters = (List<DocumentReference>) data.get("monstersScanned");
 
             /*
@@ -233,7 +233,7 @@ public class UserController {
                         int monsterScore = ((Long) monsterData.get("score")).intValue();
                         GeoPoint location = (GeoPoint) monsterData.get("location");
                         byte[] envPhoto = (byte[]) monsterData.get("envPhoto");
-                        fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId(), location.getLongitude(), location.getLatitude(), envPhoto));
+                        fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId().toString(), location.getLongitude(), location.getLatitude(), envPhoto));
                     }
                 }
                 allUsers.add(fetchedUser);
@@ -261,7 +261,7 @@ public class UserController {
                 String deviceId = (String) data.get("deviceID");
                 int score = ((Long) data.get("score")).intValue();
                 String description = (String) data.get("description");
-                User fetchedUser = new User(deviceId, document.getId(), email, description);
+                User fetchedUser = new User(deviceId, document.getId().toString(), email, description);
                 List<DocumentReference> monsters = (List<DocumentReference>) data.get("monstersScanned");
 
             /*
@@ -279,7 +279,7 @@ public class UserController {
                         int monsterScore = ((Long) monsterData.get("score")).intValue();
                         GeoPoint location = (GeoPoint) monsterData.get("location");
                         byte[] envPhoto = (byte[]) monsterData.get("envPhoto");
-                        fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId(), location.getLongitude(), location.getLatitude(), envPhoto));
+                        fetchedUser.addMonster(new Monster(monsterName, monsterScore, doc.getId().toString(), location.getLongitude(), location.getLatitude(), envPhoto));
                     }
                 }
                 allUsers.add(fetchedUser);


### PR DESCRIPTION
## Monster Controller Changes
- Fixed issue where illegal hex value would be in the hexCode of the monster – this is due to the fact that when calling ```.getId()``` on a firestore object, it doesn't return it as a ```String``` so it includes weird characters that should not be there.

## User Controller Changes
- changed all ```.getId()``` calls to ```.getId.toString()``` to make sure we get the ```String``` value instead of the firestore id type.