### PR TITLE
Fetching all Monsters returns the monsters in sorted order

### DIFF
--- a/app/app/src/main/java/cmput/app/catch_me_if_you_scan/MonsterController.java
+++ b/app/app/src/main/java/cmput/app/catch_me_if_you_scan/MonsterController.java
@@ -16,6 +16,7 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.GeoPoint;
+import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
@@ -124,7 +125,7 @@ public class MonsterController {
      */
     public ArrayList<Monster> getAllMonsters() {
         ArrayList<Monster> allMonsters = new ArrayList<Monster>();
-        Task<QuerySnapshot> task = collection.get();
+        Task<QuerySnapshot> task = collection.orderBy("score", Query.Direction.DESCENDING).get();
         while (!task.isSuccessful()) {
             continue;
         }


### PR DESCRIPTION
## Monster Controller Changes
- When calling ``getAllMonsters()``, the ArrayList of Monsters returned will be in DESCENDING order (highest is index 0)
- This will enable us to avoid sorting the monsters in the fragment and speeding up the app